### PR TITLE
leaving all icons packed, removing modification of icon path for production environments

### DIFF
--- a/.electron-builder.js
+++ b/.electron-builder.js
@@ -42,10 +42,7 @@ module.exports = {
       'AppImage'
     ],
     executableName: productName,
-    category: 'Network',
-    asarUnpack: [
-      'icons/*.png'
-    ]
+    category: 'Network'
   },
   appImage: {
     artifactName: `${fileName}-v\${version}-Linux.\${ext}`

--- a/lib/icon.js
+++ b/lib/icon.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const is = require('./is.js');
 
 const iconMap = {
   'win32-runtime': 'icons/icon.ico',
@@ -17,11 +16,7 @@ module.exports = (type = 'runtime') => {
     return icon;
   }
 
-  if (icon && is.prod) {
-    icon = icon.replace('app.asar', 'app.asar.unpacked');
-  }
-
-  if (process.platform === 'win32' && !is.prod) {
+  if (process.platform === 'win32') {
     return icon;
   }
 


### PR DESCRIPTION
This fixes the app not starting in production builds.